### PR TITLE
Update once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 crossbeam-channel = "0.5"
 num_cpus = "1"
-once_cell = ">=1.0, <=1.14"
+once_cell = "1.18.0"
 waker-fn = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Update the dependency specified. Fixes error when using with criterion. Passes tests

```
$> cargo add threadfin
    Updating crates.io index
      Adding threadfin v0.1.2 to dependencies.
    Updating crates.io index
error: failed to select a version for `once_cell`.
    ... required by package `threadfin v0.1.2`
    ... which satisfies dependency `threadfin = "^0.1.2"` of package `package v0.1.0`
versions that meet the requirements `>=1.0, <=1.14` are: 1.14.0, 1.13.1, 1.13.0, 1.12.1, 1.12.0, 1.11.0, 1.10.0, 1.9.0, 1.8.0, 1.7.2, 1.7.1, 1.7.0, 1.6.0, 1.5.2, 1.5.1, 1.4.1, 1.4.0, 1.3.1, 1.3.0, 1.2.0, 1.1.0, 1.0.2, 1.0.1

all possible versions conflict with previously selected packages.

  previously selected package `once_cell v1.17.1`
    ... which satisfies dependency `once_cell = "^1.14"` of package `criterion v0.5.1`
    ... which satisfies dependency `criterion = "^0.5.1"` of package `package v0.1.0`

failed to select a version for `once_cell` which could resolve this conflict
```

Branch `use_std` on my fork also uses the new std equivalents from 1.70.0 and gets rid of the dependence on `once_cell`, whenever you would be okay with bumping the msrv.